### PR TITLE
Fix installation step

### DIFF
--- a/_docs/07-install.md
+++ b/_docs/07-install.md
@@ -44,6 +44,6 @@ When your machine will be up to date, we can run the Nanosaur installation scrip
 
 :clipboard: Copy and paste on the NVIDIA Jetson terminal the following line
 
-{% capture code %}curl https://raw.githubusercontent.com/rnanosaur/nanosaur/master/nanosaur/scripts/nanosaur -o $HOME/nanosaur && chmod +x $HOME/nanosaur && nanosaur install{% endcapture %}{% include code.html code=code lang="sh" copyable=true %}
+{% capture code %}curl https://raw.githubusercontent.com/rnanosaur/nanosaur/master/nanosaur/scripts/nanosaur -o $HOME/nanosaur && chmod +x $HOME/nanosaur && $HOME/nanosaur install{% endcapture %}{% include code.html code=code lang="sh" copyable=true %}
 
 Follow the instructions and reboot your board!


### PR DESCRIPTION
It seems like specifying the absolute path to the `$HOME/nanosaur` is required on execution.

The current command shows the following error.

```
$ curl https://raw.githubusercontent.com/rnanosaur/nanosaur/master/nanosaur/scripts/nanosaur -o $HOME/nanosaur && chmod +x $HOME/nanosaur && nanosaur install
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 23433  100 23433    0     0  86788      0 --:--:-- --:--:-- --:--:-- 86788
-bash: nanosaur: command not found
```